### PR TITLE
Add ec2 scheduling module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,21 +7,21 @@ repos:
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'
-      # - id: terraform_tflint
-      #   args:
-      #     - '--args=--only=terraform_deprecated_interpolation'
-      #     - '--args=--only=terraform_deprecated_index'
-      #     - '--args=--only=terraform_unused_declarations'
-      #     - '--args=--only=terraform_comment_syntax'
-      #     - '--args=--only=terraform_documented_outputs'
-      #     - '--args=--only=terraform_documented_variables'
-      #     - '--args=--only=terraform_typed_variables'
-      #     - '--args=--only=terraform_module_pinned_source'
-      #     - '--args=--only=terraform_naming_convention'
-      #     - '--args=--only=terraform_required_version'
-      #     - '--args=--only=terraform_required_providers'
-      #     - '--args=--only=terraform_standard_module_structure'
-      #     - '--args=--only=terraform_workspace_remote'
+      - id: terraform_tflint
+        args:
+          - '--args=--only=terraform_deprecated_interpolation'
+          - '--args=--only=terraform_deprecated_index'
+          - '--args=--only=terraform_unused_declarations'
+          - '--args=--only=terraform_comment_syntax'
+          - '--args=--only=terraform_documented_outputs'
+          - '--args=--only=terraform_documented_variables'
+          - '--args=--only=terraform_typed_variables'
+          - '--args=--only=terraform_module_pinned_source'
+          - '--args=--only=terraform_naming_convention'
+          - '--args=--only=terraform_required_version'
+          - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_standard_module_structure'
+          - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,25 +3,25 @@ repos:
     rev: v1.77.0
     hooks:
       - id: terraform_fmt
-      # - id: terraform_validate
+      - id: terraform_validate
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'
-      # - id: terraform_tflint
-      #   args:
-      #     - '--args=--only=terraform_deprecated_interpolation'
-      #     - '--args=--only=terraform_deprecated_index'
-      #     - '--args=--only=terraform_unused_declarations'
-      #     - '--args=--only=terraform_comment_syntax'
-      #     - '--args=--only=terraform_documented_outputs'
-      #     - '--args=--only=terraform_documented_variables'
-      #     - '--args=--only=terraform_typed_variables'
-      #     - '--args=--only=terraform_module_pinned_source'
-      #     - '--args=--only=terraform_naming_convention'
-      #     - '--args=--only=terraform_required_version'
-      #     - '--args=--only=terraform_required_providers'
-      #     - '--args=--only=terraform_standard_module_structure'
-      #     - '--args=--only=terraform_workspace_remote'
+      - id: terraform_tflint
+        args:
+          - '--args=--only=terraform_deprecated_interpolation'
+          - '--args=--only=terraform_deprecated_index'
+          - '--args=--only=terraform_unused_declarations'
+          - '--args=--only=terraform_comment_syntax'
+          - '--args=--only=terraform_documented_outputs'
+          - '--args=--only=terraform_documented_variables'
+          - '--args=--only=terraform_typed_variables'
+          - '--args=--only=terraform_module_pinned_source'
+          - '--args=--only=terraform_naming_convention'
+          - '--args=--only=terraform_required_version'
+          - '--args=--only=terraform_required_providers'
+          - '--args=--only=terraform_standard_module_structure'
+          - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,21 +7,21 @@ repos:
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'
-      - id: terraform_tflint
-        args:
-          - '--args=--only=terraform_deprecated_interpolation'
-          - '--args=--only=terraform_deprecated_index'
-          - '--args=--only=terraform_unused_declarations'
-          - '--args=--only=terraform_comment_syntax'
-          - '--args=--only=terraform_documented_outputs'
-          - '--args=--only=terraform_documented_variables'
-          - '--args=--only=terraform_typed_variables'
-          - '--args=--only=terraform_module_pinned_source'
-          - '--args=--only=terraform_naming_convention'
-          - '--args=--only=terraform_required_version'
-          - '--args=--only=terraform_required_providers'
-          - '--args=--only=terraform_standard_module_structure'
-          - '--args=--only=terraform_workspace_remote'
+      # - id: terraform_tflint
+      #   args:
+      #     - '--args=--only=terraform_deprecated_interpolation'
+      #     - '--args=--only=terraform_deprecated_index'
+      #     - '--args=--only=terraform_unused_declarations'
+      #     - '--args=--only=terraform_comment_syntax'
+      #     - '--args=--only=terraform_documented_outputs'
+      #     - '--args=--only=terraform_documented_variables'
+      #     - '--args=--only=terraform_typed_variables'
+      #     - '--args=--only=terraform_module_pinned_source'
+      #     - '--args=--only=terraform_naming_convention'
+      #     - '--args=--only=terraform_required_version'
+      #     - '--args=--only=terraform_required_providers'
+      #     - '--args=--only=terraform_standard_module_structure'
+      #     - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,25 +3,25 @@ repos:
     rev: v1.77.0
     hooks:
       - id: terraform_fmt
-      - id: terraform_validate
+      # - id: terraform_validate
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'
-      - id: terraform_tflint
-        args:
-          - '--args=--only=terraform_deprecated_interpolation'
-          - '--args=--only=terraform_deprecated_index'
-          - '--args=--only=terraform_unused_declarations'
-          - '--args=--only=terraform_comment_syntax'
-          - '--args=--only=terraform_documented_outputs'
-          - '--args=--only=terraform_documented_variables'
-          - '--args=--only=terraform_typed_variables'
-          - '--args=--only=terraform_module_pinned_source'
-          - '--args=--only=terraform_naming_convention'
-          - '--args=--only=terraform_required_version'
-          - '--args=--only=terraform_required_providers'
-          - '--args=--only=terraform_standard_module_structure'
-          - '--args=--only=terraform_workspace_remote'
+      # - id: terraform_tflint
+      #   args:
+      #     - '--args=--only=terraform_deprecated_interpolation'
+      #     - '--args=--only=terraform_deprecated_index'
+      #     - '--args=--only=terraform_unused_declarations'
+      #     - '--args=--only=terraform_comment_syntax'
+      #     - '--args=--only=terraform_documented_outputs'
+      #     - '--args=--only=terraform_documented_variables'
+      #     - '--args=--only=terraform_typed_variables'
+      #     - '--args=--only=terraform_module_pinned_source'
+      #     - '--args=--only=terraform_naming_convention'
+      #     - '--args=--only=terraform_required_version'
+      #     - '--args=--only=terraform_required_providers'
+      #     - '--args=--only=terraform_standard_module_structure'
+      #     - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>map(object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  }))</pre> | `{}` | no |
-| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>map(object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  }))</pre> | `{}` | no |
-| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>map(object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | `{}` | no |
+| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `{}` | no |
+| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ as described in the `.pre-commit-config.yaml` file
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -85,11 +89,36 @@ No modules.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.asg_downscale_scheduler_event](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.asg_upscale_scheduler_event](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.ec2_start_scheduler_event](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.ec2_stop_scheduler_event](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.asg_downscale_scheduler_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.asg_upscale_scheduler_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.ec2_start_scheduler_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.ec2_stop_scheduler_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_iam_policy.ec2_scheduler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.attach_iam_policy_to_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.lambda_asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [random_integer.random_number](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [archive_file.lambda_asg](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_iam_policy_document.ec2_scheduler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>map(object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  }))</pre> | `{}` | no |
+| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>map(object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>map(object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ No modules.
 | [aws_lambda_function.lambda_asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
-| [random_integer.random_number](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) | resource |
+| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/id) | resource |
 | [archive_file.lambda_asg](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |
 | [archive_file.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |
 | [archive_file.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | <pre>{<br>  "asg_name": "",<br>  "downscale_cron_expression": "",<br>  "downscale_desired_capacity": 1,<br>  "upscale_cron_expression": "",<br>  "upscale_desired_capacity": 2<br>}</pre> | no |
-| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | <pre>{<br>  "cron_expression": "",<br>  "instance_ids": []<br>}</pre> | no |
-| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | <pre>{<br>  "cron_expression": "",<br>  "instance_ids": []<br>}</pre> | no |
+| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | `null` | no |
+| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `null` | no |
+| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>map({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | `{}` | no |
-| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>map({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `{}` | no |
-| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>map({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `{}` | no |
+| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>map(object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  }))</pre> | `{}` | no |
+| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>map(object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>map(object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | n/a | yes |
-| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | n/a | yes |
-| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | <pre>{<br>  "asg_name": "",<br>  "downscale_cron_expression": "",<br>  "downscale_desired_capacity": 1,<br>  "upscale_cron_expression": "",<br>  "upscale_desired_capacity": 2<br>}</pre> | no |
+| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | <pre>{<br>  "cron_expression": "",<br>  "instance_ids": []<br>}</pre> | no |
+| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | <pre>{<br>  "cron_expression": "",<br>  "instance_ids": []<br>}</pre> | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -73,15 +73,17 @@ as described in the `.pre-commit-config.yaml` file
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | 2.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.5.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
 
 ## Modules
 
@@ -105,10 +107,10 @@ No modules.
 | [aws_lambda_function.lambda_asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
-| [random_integer.random_number](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
-| [archive_file.lambda_asg](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [archive_file.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [archive_file.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [random_integer.random_number](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/integer) | resource |
+| [archive_file.lambda_asg](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |
+| [archive_file.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |
+| [archive_file.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |
 | [aws_iam_policy_document.ec2_scheduler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>map(object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  }))</pre> | `{}` | no |
-| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>map(object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  }))</pre> | `{}` | no |
-| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>map(object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  }))</pre> | `{}` | no |
+| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>map({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | `{}` | no |
+| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>map({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `{}` | no |
+| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>map({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,42 @@
-# < This section can be removed >
+# Up Down scheduler
 
-Official doc for public modules [hashicorp](https://developer.hashicorp.com/terraform/registry/modules/publish)
-
-Repo structure:
-
-```
-├── README.md
-├── main.tf
-├── variables.tf
-├── outputs.tf
-├── ...
-├── modules/
-│   ├── nestedA/
-│   │   ├── README.md
-│   │   ├── variables.tf
-│   │   ├── main.tf
-│   │   ├── outputs.tf
-│   ├── nestedB/
-│   ├── .../
-├── examples/
-│   ├── exampleA/
-│   │   ├── main.tf
-│   ├── exampleB/
-│   ├── .../
-```
-
-# My Terraform Module
-
-< module description >
+This Terraform module automates the scheduling of AWS Auto Scaling Group (ASG) scaling events and the start/stop scheduling of EC2 instances using AWS Lambda and Amazon CloudWatch Events. The module is designed to optimize resource management by automatically adjusting ASG capacities and controlling EC2 instance states based on predefined schedules.
 
 ## Usage
 
-< describe the module minimal code required for a deployment >
+You can use the module two ways:
 
 ```hcl
-module "my_module_example" {
+module "ec2_start_stop_app_with_asg" {
+  source        = "github.com/tx-pts-dai/terraform-aws-up-down-scheduler"
+  version       = "~> 1.0"
+  asg_scheduler = {
+    downscale_cron_expression  = "0 17 * * MON-FRI"
+    downscale_desired_capacity = 1
+    upscale_cron_expression    = "0 8 * * MON-FRI"
+    upscale_desired_capacity   = 2
+    asg_name                   = "My-ASG-APP"
+  }
+}
+
+module "ec2_start_stop_app_without_asg" {
+  source              = "github.com/tx-pts-dai/terraform-aws-up-down-scheduler"
+  version             = "~> 1.0"
+  ec2_stop_scheduler  = {
+    cron_expression = "0 17 * * MON-FRI"
+    instance_ids    = ["i-xxxxxxxxxxxxx"]
+  }
+  ec2_start_scheduler = {
+    cron_expression = "0 8 * * MON-FRI"
+    instance_ids    = ["i-xxxxxxxxxxxxx"]
+  }
 }
 ```
 
 ## Explanation and description of interesting use-cases
 
-< create a h2 chapter for each section explaining special module concepts >
-
-## Examples
-
-< if the folder `examples/` exists, put here the link to the examples subfolders with their descriptions >
-
-## Contributing
-
-< issues and contribution guidelines for public modules >
+## Save money !
+Don't spend useless money when your workloads are not used or are in stand by anyway. A good use case is stopping dev services during the night or scale less instances on internal applications that are accessed only during the day anyway.
 
 ### Pre-Commit
 

--- a/README.md
+++ b/README.md
@@ -73,17 +73,17 @@ as described in the `.pre-commit-config.yaml` file
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_archive"></a> [archive](#requirement\_archive) | 2.5.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.5.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
 
@@ -107,10 +107,10 @@ No modules.
 | [aws_lambda_function.lambda_asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
-| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/3.6.2/docs/resources/id) | resource |
-| [archive_file.lambda_asg](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |
-| [archive_file.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |
-| [archive_file.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/archive/2.5.0/docs/data-sources/file) | data source |
+| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [archive_file.lambda_asg](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.lambda_ec2_start](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.lambda_ec2_stop](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_iam_policy_document.ec2_scheduler_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | `{}` | no |
-| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `{}` | no |
-| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | `{}` | no |
+| <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>object({<br>    downscale_cron_expression  = string<br>    downscale_desired_capacity = number<br>    upscale_cron_expression    = string<br>    upscale_desired_capacity   = number<br>    asg_name                   = string<br>  })</pre> | n/a | yes |
+| <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | n/a | yes |
+| <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>object({<br>    cron_expression = string<br>    instance_ids    = list(string)<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/lambda/ec2_asg/update_capacity/main.py
+++ b/lambda/ec2_asg/update_capacity/main.py
@@ -15,4 +15,7 @@ def lambda_handler(event, context):
         }
     except Exception as e:
         print(f"Error updating capacity of autoscaling group {asg_name}: {str(e)}")
-        return {"statusCode": 500, "body": f"Error updating desired capacity: {str(e)}"}
+        return {
+            "statusCode": 500,
+            "body": f"Error updating desired capacity: {str(e)}",
+        }

--- a/lambda/ec2_asg/update_capacity/main.py
+++ b/lambda/ec2_asg/update_capacity/main.py
@@ -1,0 +1,18 @@
+import boto3
+
+def lambda_handler(event, context):
+    desired_capacity = event["desired_capacity"]
+    asg_name = event["asg_name"]
+    ec2_client = boto3.client("ec2")
+    try:
+        response = ec2_client.update_auto_scaling_group(
+            AutoScalingGroupName=asg_name, DesiredCapacity=desired_capacity
+        )
+        print(response)
+        return {
+            "statusCode": 200,
+            "body": f"Successfully updated desired capacity to {desired_capacity}",
+        }
+    except Exception as e:
+        print(f"Error updating capacity of autoscaling group {asg_name}: {str(e)}")
+        return {"statusCode": 500, "body": f"Error updating desired capacity: {str(e)}"}

--- a/lambda/ec2_simple/start/main.py
+++ b/lambda/ec2_simple/start/main.py
@@ -1,0 +1,20 @@
+import boto3
+
+def lambda_handler(event, context):
+    ec2 = boto3.client("ec2")
+    instance_id = event.get("instance_id")
+
+    try:
+        response = ec2.start_instances(InstanceIds=[instance_id])
+        print(response)
+        return {
+            "statusCode": 200,
+            "body": f"Successfully started instance {instance_id}",
+            "response": response,
+        }
+    except Exception as e:
+        print(f"Error starting instance {instance_id}: {str(e)}")
+        return {
+            "statusCode": 500,
+            "body": f"Error starting instance {instance_id}: {str(e)}",
+        }

--- a/lambda/ec2_simple/start/main.py
+++ b/lambda/ec2_simple/start/main.py
@@ -3,7 +3,6 @@ import boto3
 def lambda_handler(event, context):
     ec2 = boto3.client("ec2")
     instance_id = event.get("instance_id")
-
     try:
         response = ec2.start_instances(InstanceIds=[instance_id])
         print(response)

--- a/lambda/ec2_simple/stop/main.py
+++ b/lambda/ec2_simple/stop/main.py
@@ -1,0 +1,19 @@
+import boto3
+
+def lambda_handler(event, context):
+    instance_id = event['instance_id']
+    try:
+        ec2 = boto3.client('ec2')
+        response = ec2.stop_instances(InstanceIds=[instance_id])
+        print(response)
+        return {
+            "statusCode": 200,
+            "body": f"Successfully stopped instance {instance_id}",
+            "response": response,
+        }
+    except Exception as e:
+        print(f"Error stopping instance {instance_id}: {str(e)}")
+        return {
+            "statusCode": 500,
+            "body": f"Error stopping instance {instance_id}: {str(e)}",
+        }

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ terraform {
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "2.5.0"
+      version = "~> 2.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ data "archive_file" "lambda_asg" {
 
 resource "aws_lambda_function" "lambda_asg" {
   count            = var.asg_scheduler != null ? 1 : 0
-  function_name    = "ec2-asg-scheduler-${random_integer.random_number.result}"
+  function_name    = "ec2-asg-scheduler-${random_id.this.id}"
   filename         = data.archive_file.lambda_asg[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_asg[0].output_path)
   handler          = "main.lambda_handler"
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "lambda_asg" {
 
 resource "aws_cloudwatch_event_rule" "asg_downscale_scheduler_event" {
   count               = var.asg_scheduler != null ? 1 : 0
-  name                = "asg-scheduler-downscale-event-${random_integer.random_number.result}"
+  name                = "asg-scheduler-downscale-event-${random_id.this.id}"
   description         = "Event rule for ASG downscale scheduler"
   schedule_expression = var.asg_scheduler.downscale_cron_expression
 }
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
 
 resource "aws_cloudwatch_event_rule" "asg_upscale_scheduler_event" {
   count               = var.asg_scheduler != null ? 1 : 0
-  name                = "asg-scheduler-upsacale-event-${random_integer.random_number.result}"
+  name                = "asg-scheduler-upsacale-event-${random_id.this.id}"
   description         = "Event rule for ASG upscale scheduler"
   schedule_expression = var.asg_scheduler.upscale_cron_expression
 }
@@ -79,7 +79,7 @@ data "archive_file" "lambda_ec2_stop" {
 
 resource "aws_lambda_function" "lambda_ec2_stop" {
   count            = var.ec2_stop_scheduler != null ? 1 : 0
-  function_name    = "ec2-stop-scheduler-${random_integer.random_number.result}"
+  function_name    = "ec2-stop-scheduler-${random_id.this.id}"
   filename         = data.archive_file.lambda_ec2_stop[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_stop[0].output_path)
   handler          = "main.lambda_handler"
@@ -89,7 +89,7 @@ resource "aws_lambda_function" "lambda_ec2_stop" {
 
 resource "aws_cloudwatch_event_rule" "ec2_stop_scheduler_event" {
   count               = var.ec2_stop_scheduler != null ? 1 : 0
-  name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
+  name                = "ec2-start-scheduler-event-${random_id.this.id}"
   description         = "Event rule for EC2 stop scheduler"
   schedule_expression = var.ec2_stop_scheduler.cron_expression
 }
@@ -113,7 +113,7 @@ data "archive_file" "lambda_ec2_start" {
 
 resource "aws_lambda_function" "lambda_ec2_start" {
   count            = var.ec2_start_scheduler != null ? 1 : 0
-  function_name    = "ec2-start-scheduler-${random_integer.random_number.result}"
+  function_name    = "ec2-start-scheduler-${random_id.this.id}"
   filename         = data.archive_file.lambda_ec2_start[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_start[0].output_path)
   handler          = "main.lambda_handler"
@@ -123,7 +123,7 @@ resource "aws_lambda_function" "lambda_ec2_start" {
 
 resource "aws_cloudwatch_event_rule" "ec2_start_scheduler_event" {
   count               = var.ec2_start_scheduler != null ? 1 : 0
-  name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
+  name                = "ec2-start-scheduler-event-${random_id.this.id}"
   description         = "Event rule for EC2 start scheduler"
   schedule_expression = var.ec2_start_scheduler.cron_expression
 }
@@ -138,13 +138,12 @@ resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
   })
 }
 
-resource "random_integer" "random_number" {
-  min = 1000
-  max = 9999
+resource "random_id" "this" {
+  byte_length = 4
 }
 
 resource "aws_iam_role" "lambda_role" {
-  name               = "ec2-scheduler-role-${random_integer.random_number.result}"
+  name               = "ec2-scheduler-role-${random_id.this.id}"
   assume_role_policy = data.aws_iam_policy_document.lambda_role_policy.json
 }
 
@@ -179,7 +178,7 @@ data "aws_iam_policy_document" "ec2_scheduler_policy" {
 }
 
 resource "aws_iam_policy" "ec2_scheduler_policy" {
-  name   = "ec2-scheduler-${random_integer.random_number.result}"
+  name   = "ec2-scheduler-${random_id.this.id}"
   policy = data.aws_iam_policy_document.ec2_scheduler_policy.json
 }
 

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_event_rule" "asg_upscale_scheduler_event" {
   count               = var.asg_scheduler != {} ? 1 : 0
   name                = "asg-scheduler-upsacale-event-${random_integer.random_number.result}"
   description         = "Event rule for ASG upscale scheduler"
-  schedule_expression = var.asg_scheduler["upscale_cron_expression"]
+  schedule_expression = var.asg_scheduler[0].upscale_cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ terraform {
 data "archive_file" "lambda_asg" {
   count       = var.asg_scheduler != {} ? 1 : 0
   type        = "zip"
-  source_dir  = "${path.module}/lambda/ec2_asg/update_capacity/main.py"
+  source_dir  = "${path.module}/lambda/ec2_asg/update_capacity"
   output_path = "${path.module}/lambda/ec2_asg/update_capacity/package.zip"
 }
 
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
 data "archive_file" "lambda_ec2_stop" {
   count       = var.ec2_stop_scheduler != {} ? 1 : 0
   type        = "zip"
-  source_dir  = "${path.module}/lambda/ec2_simple/stop/main.py"
+  source_dir  = "${path.module}/lambda/ec2_simple/stop"
   output_path = "${path.module}/lambda/ec2_simple/stop/package.zip"
 }
 
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
 data "archive_file" "lambda_ec2_start" {
   count       = var.ec2_start_scheduler != {} ? 1 : 0
   type        = "zip"
-  source_dir  = "${path.module}/lambda/ec2_simple/start/main.py"
+  source_dir  = "${path.module}/lambda/ec2_simple/start"
   output_path = "${path.module}/lambda/ec2_simple/start/package.zip"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.6.2"
+      version = "~> 3.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_event_rule" "asg_downscale_scheduler_event" {
   count               = var.asg_scheduler != {} ? 1 : 0
   name                = "asg-scheduler-downscale-event-${random_integer.random_number.result}"
   description         = "Event rule for ASG downscale scheduler"
-  schedule_expression = var.asg_scheduler.downscale_cron_expression
+  schedule_expression = var.asg_scheduler[0].downscale_cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
@@ -39,8 +39,8 @@ resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
   target_id = aws_lambda_function.lambda_asg[0].function_name
   arn       = aws_lambda_function.lambda_asg[0].arn
   input = jsonencode({
-    asg_name         = var.asg_scheduler.asg_name
-    desired_capacity = var.asg_scheduler.downscale_desired_capacity
+    asg_name         = var.asg_scheduler[0].asg_name
+    desired_capacity = var.asg_scheduler[0].downscale_desired_capacity
   })
 }
 
@@ -57,8 +57,8 @@ resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
   target_id = aws_lambda_function.lambda_asg[0].function_name
   arn       = aws_lambda_function.lambda_asg[0].arn
   input = jsonencode({
-    asg_name         = var.asg_scheduler.asg_name
-    desired_capacity = var.asg_scheduler.upscale_desired_capacity
+    asg_name         = var.asg_scheduler[0].asg_name
+    desired_capacity = var.asg_scheduler[0].upscale_desired_capacity
   })
 }
 
@@ -83,7 +83,7 @@ resource "aws_cloudwatch_event_rule" "ec2_stop_scheduler_event" {
   count               = var.ec2_stop_scheduler != {} ? 1 : 0
   name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
   description         = "Event rule for EC2 stop scheduler"
-  schedule_expression = var.ec2_stop_scheduler.cron_expression
+  schedule_expression = var.ec2_stop_scheduler[0].cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
@@ -92,7 +92,7 @@ resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
   target_id = aws_lambda_function.lambda_ec2_stop[0].function_name
   arn       = aws_lambda_function.lambda_ec2_stop[0].arn
   input = jsonencode({
-    instance_ids = var.ec2_stop_scheduler.instance_ids
+    instance_ids = var.ec2_stop_scheduler[0].instance_ids
   })
 }
 
@@ -117,7 +117,7 @@ resource "aws_cloudwatch_event_rule" "ec2_start_scheduler_event" {
   count               = var.ec2_start_scheduler != {} ? 1 : 0
   name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
   description         = "Event rule for EC2 start scheduler"
-  schedule_expression = var.ec2_start_scheduler.cron_expression
+  schedule_expression = var.ec2_start_scheduler[0].cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
@@ -126,7 +126,7 @@ resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
   target_id = aws_lambda_function.lambda_ec2_start[0].function_name
   arn       = aws_lambda_function.lambda_ec2_start[0].arn
   input = jsonencode({
-    instance_ids = var.ec2_start_scheduler.instance_ids
+    instance_ids = var.ec2_start_scheduler[0].instance_ids
   })
 }
 

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ data "archive_file" "lambda_asg" {
 }
 
 resource "aws_lambda_function" "lambda_asg" {
-  count            = var.asg_scheduler != {} ? 1 : 0
+  count            = var.asg_scheduler.asg_name != "" ? 1 : 0
   function_name    = "ec2-asg-scheduler-${random_integer.random_number.result}"
   filename         = data.archive_file.lambda_asg[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_asg[0].output_path)
@@ -27,14 +27,14 @@ resource "aws_lambda_function" "lambda_asg" {
 
 
 resource "aws_cloudwatch_event_rule" "asg_downscale_scheduler_event" {
-  count               = var.asg_scheduler != {} ? 1 : 0
+  count               = var.asg_scheduler.asg_name != "" ? 1 : 0
   name                = "asg-scheduler-downscale-event-${random_integer.random_number.result}"
   description         = "Event rule for ASG downscale scheduler"
   schedule_expression = var.asg_scheduler.downscale_cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
-  count     = var.asg_scheduler != {} ? 1 : 0
+  count     = var.asg_scheduler.asg_name != "" ? 1 : 0
   rule      = aws_cloudwatch_event_rule.asg_downscale_scheduler_event[0].name
   target_id = aws_lambda_function.lambda_asg[0].function_name
   arn       = aws_lambda_function.lambda_asg[0].arn
@@ -45,14 +45,14 @@ resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
 }
 
 resource "aws_cloudwatch_event_rule" "asg_upscale_scheduler_event" {
-  count               = var.asg_scheduler != {} ? 1 : 0
+  count               = var.asg_scheduler.asg_name != "" ? 1 : 0
   name                = "asg-scheduler-upsacale-event-${random_integer.random_number.result}"
   description         = "Event rule for ASG upscale scheduler"
   schedule_expression = var.asg_scheduler.upscale_cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
-  count     = var.asg_scheduler != {} ? 1 : 0
+  count     = var.asg_scheduler.asg_name != "" ? 1 : 0
   rule      = aws_cloudwatch_event_rule.asg_upscale_scheduler_event[0].name
   target_id = aws_lambda_function.lambda_asg[0].function_name
   arn       = aws_lambda_function.lambda_asg[0].arn
@@ -63,14 +63,14 @@ resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
 }
 
 data "archive_file" "lambda_ec2_stop" {
-  count       = var.ec2_stop_scheduler != {} ? 1 : 0
+  count       = var.ec2_stop_scheduler.cron_expression != "" ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/lambda/ec2_simple/stop"
   output_path = "${path.module}/lambda/ec2_simple/stop/package.zip"
 }
 
 resource "aws_lambda_function" "lambda_ec2_stop" {
-  count            = var.ec2_stop_scheduler != {} ? 1 : 0
+  count            = var.ec2_stop_scheduler.cron_expression != "" ? 1 : 0
   function_name    = "ec2-stop-scheduler-${random_integer.random_number.result}"
   filename         = data.archive_file.lambda_ec2_stop[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_stop[0].output_path)
@@ -80,14 +80,14 @@ resource "aws_lambda_function" "lambda_ec2_stop" {
 }
 
 resource "aws_cloudwatch_event_rule" "ec2_stop_scheduler_event" {
-  count               = var.ec2_stop_scheduler != {} ? 1 : 0
+  count               = var.ec2_stop_scheduler.cron_expression != "" ? 1 : 0
   name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
   description         = "Event rule for EC2 stop scheduler"
   schedule_expression = var.ec2_stop_scheduler.cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
-  count     = var.ec2_stop_scheduler != {} ? 1 : 0
+  count     = var.ec2_stop_scheduler.cron_expression != "" ? 1 : 0
   rule      = aws_cloudwatch_event_rule.ec2_stop_scheduler_event[0].name
   target_id = aws_lambda_function.lambda_ec2_stop[0].function_name
   arn       = aws_lambda_function.lambda_ec2_stop[0].arn
@@ -97,14 +97,14 @@ resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
 }
 
 data "archive_file" "lambda_ec2_start" {
-  count       = var.ec2_start_scheduler != {} ? 1 : 0
+  count       = var.ec2_start_scheduler.cron_expression != "" ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/lambda/ec2_simple/start"
   output_path = "${path.module}/lambda/ec2_simple/start/package.zip"
 }
 
 resource "aws_lambda_function" "lambda_ec2_start" {
-  count            = var.ec2_start_scheduler != {} ? 1 : 0
+  count            = var.ec2_start_scheduler.cron_expression != "" ? 1 : 0
   function_name    = "ec2-start-scheduler-${random_integer.random_number.result}"
   filename         = data.archive_file.lambda_ec2_start[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_start[0].output_path)
@@ -114,14 +114,14 @@ resource "aws_lambda_function" "lambda_ec2_start" {
 }
 
 resource "aws_cloudwatch_event_rule" "ec2_start_scheduler_event" {
-  count               = var.ec2_start_scheduler != {} ? 1 : 0
+  count               = var.ec2_start_scheduler.cron_expression != "" ? 1 : 0
   name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
   description         = "Event rule for EC2 start scheduler"
   schedule_expression = var.ec2_start_scheduler.cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
-  count     = var.ec2_start_scheduler != {} ? 1 : 0
+  count     = var.ec2_start_scheduler.cron_expression != "" ? 1 : 0
   rule      = aws_cloudwatch_event_rule.ec2_start_scheduler_event[0].name
   target_id = aws_lambda_function.lambda_ec2_start[0].function_name
   arn       = aws_lambda_function.lambda_ec2_start[0].arn

--- a/main.tf
+++ b/main.tf
@@ -7,3 +7,175 @@ terraform {
     }
   }
 }
+
+data "archive_file" "lambda_asg" {
+  count       = var.asg_scheduler != {} ? 1 : 0
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/ec2_asg/update_capacity/main.py"
+  output_path = "${path.module}/lambda/ec2_asg/update_capacity/package.zip"
+}
+
+resource "aws_lambda_function" "lambda_asg" {
+  count            = var.asg_scheduler != {} ? 1 : 0
+  function_name    = "ec2-asg-scheduler-${random_integer.random_number.result}"
+  filename         = data.archive_file.lambda_asg[0].output_path
+  source_code_hash = filebase64sha256(data.archive_file.lambda_asg[0].output_path)
+  handler          = "main.lambda_handler"
+  runtime          = "python3.8"
+  role             = aws_iam_role.lambda_role.arn
+}
+
+
+resource "aws_cloudwatch_event_rule" "asg_downscale_scheduler_event" {
+  count               = var.asg_scheduler != {} ? 1 : 0
+  name                = "asg-scheduler-downscale-event-${random_integer.random_number.result}"
+  description         = "Event rule for ASG downscale scheduler"
+  schedule_expression = var.asg_scheduler.downscale_cron_expression
+}
+
+resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
+  count     = var.asg_scheduler != {} ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.asg_downscale_scheduler_event[0].name
+  target_id = aws_lambda_function.lambda_asg[0].function_name
+  arn       = aws_lambda_function.lambda_asg[0].arn
+  input = jsonencode({
+    asg_name         = var.asg_scheduler.asg_name
+    desired_capacity = var.asg_scheduler.downscale_desired_capacity
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "asg_upscale_scheduler_event" {
+  count               = var.asg_scheduler != {} ? 1 : 0
+  name                = "asg-scheduler-upsacale-event-${random_integer.random_number.result}"
+  description         = "Event rule for ASG upscale scheduler"
+  schedule_expression = var.asg_scheduler["upscale_cron_expression"]
+}
+
+resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
+  count     = var.asg_scheduler != {} ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.asg_upscale_scheduler_event[0].name
+  target_id = aws_lambda_function.lambda_asg[0].function_name
+  arn       = aws_lambda_function.lambda_asg[0].arn
+  input = jsonencode({
+    asg_name         = var.asg_scheduler.asg_name
+    desired_capacity = var.asg_scheduler.upscale_desired_capacity
+  })
+}
+
+data "archive_file" "lambda_ec2_stop" {
+  count       = var.ec2_stop_scheduler != {} ? 1 : 0
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/ec2_simple/stop/main.py"
+  output_path = "${path.module}/lambda/ec2_simple/stop/package.zip"
+}
+
+resource "aws_lambda_function" "lambda_ec2_stop" {
+  count            = var.ec2_stop_scheduler != {} ? 1 : 0
+  function_name    = "ec2-stop-scheduler-${random_integer.random_number.result}"
+  filename         = data.archive_file.lambda_ec2_stop[0].output_path
+  source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_stop[0].output_path)
+  handler          = "main.lambda_handler"
+  runtime          = "python3.8"
+  role             = aws_iam_role.lambda_role.arn
+}
+
+resource "aws_cloudwatch_event_rule" "ec2_stop_scheduler_event" {
+  count               = var.ec2_stop_scheduler != {} ? 1 : 0
+  name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
+  description         = "Event rule for EC2 stop scheduler"
+  schedule_expression = var.ec2_stop_scheduler.cron_expression
+}
+
+resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
+  count     = var.ec2_stop_scheduler != {} ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.ec2_stop_scheduler_event[0].name
+  target_id = aws_lambda_function.lambda_ec2_stop[0].function_name
+  arn       = aws_lambda_function.lambda_ec2_stop[0].arn
+  input = jsonencode({
+    instance_ids = var.ec2_stop_scheduler.instance_ids
+  })
+}
+
+data "archive_file" "lambda_ec2_start" {
+  count       = var.ec2_start_scheduler != {} ? 1 : 0
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/ec2_simple/start/main.py"
+  output_path = "${path.module}/lambda/ec2_simple/start/package.zip"
+}
+
+resource "aws_lambda_function" "lambda_ec2_start" {
+  count            = var.ec2_start_scheduler != {} ? 1 : 0
+  function_name    = "ec2-start-scheduler-${random_integer.random_number.result}"
+  filename         = data.archive_file.lambda_ec2_start[0].output_path
+  source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_start[0].output_path)
+  handler          = "main.lambda_handler"
+  runtime          = "python3.8"
+  role             = aws_iam_role.lambda_role.arn
+}
+
+resource "aws_cloudwatch_event_rule" "ec2_start_scheduler_event" {
+  count               = var.ec2_start_scheduler != {} ? 1 : 0
+  name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
+  description         = "Event rule for EC2 start scheduler"
+  schedule_expression = var.ec2_start_scheduler.cron_expression
+}
+
+resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
+  count     = var.ec2_start_scheduler != {} ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.ec2_start_scheduler_event[0].name
+  target_id = aws_lambda_function.lambda_ec2_start[0].function_name
+  arn       = aws_lambda_function.lambda_ec2_start[0].arn
+  input = jsonencode({
+    instance_ids = var.ec2_start_scheduler.instance_ids
+  })
+}
+
+resource "random_integer" "random_number" {
+  min = 1000
+  max = 9999
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name               = "ec2-scheduler-role-${random_integer.random_number.result}"
+  assume_role_policy = data.aws_iam_policy_document.lambda_role_policy.json
+}
+
+data "aws_iam_policy_document" "lambda_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    effect  = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ec2_scheduler_policy" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "ec2:DescribeInstances",
+      "ec2:StartInstances",
+      "ec2:StopInstances",
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:UpdateAutoScalingGroup",
+      "autoscaling:DescribeAutoScalingInstances",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ec2_scheduler_policy" {
+  name   = "ec2-scheduler-${random_integer.random_number.result}"
+  policy = data.aws_iam_policy_document.ec2_scheduler_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach_iam_policy_to_iam_role" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.ec2_scheduler_policy.arn
+}

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_event_rule" "asg_downscale_scheduler_event" {
   count               = var.asg_scheduler != {} ? 1 : 0
   name                = "asg-scheduler-downscale-event-${random_integer.random_number.result}"
   description         = "Event rule for ASG downscale scheduler"
-  schedule_expression = var.asg_scheduler[0].downscale_cron_expression
+  schedule_expression = var.asg_scheduler.downscale_cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
@@ -39,8 +39,8 @@ resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
   target_id = aws_lambda_function.lambda_asg[0].function_name
   arn       = aws_lambda_function.lambda_asg[0].arn
   input = jsonencode({
-    asg_name         = var.asg_scheduler[0].asg_name
-    desired_capacity = var.asg_scheduler[0].downscale_desired_capacity
+    asg_name         = var.asg_scheduler.asg_name
+    desired_capacity = var.asg_scheduler.downscale_desired_capacity
   })
 }
 
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_event_rule" "asg_upscale_scheduler_event" {
   count               = var.asg_scheduler != {} ? 1 : 0
   name                = "asg-scheduler-upsacale-event-${random_integer.random_number.result}"
   description         = "Event rule for ASG upscale scheduler"
-  schedule_expression = var.asg_scheduler[0].upscale_cron_expression
+  schedule_expression = var.asg_scheduler.upscale_cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
@@ -57,8 +57,8 @@ resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
   target_id = aws_lambda_function.lambda_asg[0].function_name
   arn       = aws_lambda_function.lambda_asg[0].arn
   input = jsonencode({
-    asg_name         = var.asg_scheduler[0].asg_name
-    desired_capacity = var.asg_scheduler[0].upscale_desired_capacity
+    asg_name         = var.asg_scheduler.asg_name
+    desired_capacity = var.asg_scheduler.upscale_desired_capacity
   })
 }
 
@@ -83,7 +83,7 @@ resource "aws_cloudwatch_event_rule" "ec2_stop_scheduler_event" {
   count               = var.ec2_stop_scheduler != {} ? 1 : 0
   name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
   description         = "Event rule for EC2 stop scheduler"
-  schedule_expression = var.ec2_stop_scheduler[0].cron_expression
+  schedule_expression = var.ec2_stop_scheduler.cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
@@ -92,7 +92,7 @@ resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
   target_id = aws_lambda_function.lambda_ec2_stop[0].function_name
   arn       = aws_lambda_function.lambda_ec2_stop[0].arn
   input = jsonencode({
-    instance_ids = var.ec2_stop_scheduler[0].instance_ids
+    instance_ids = var.ec2_stop_scheduler.instance_ids
   })
 }
 
@@ -117,7 +117,7 @@ resource "aws_cloudwatch_event_rule" "ec2_start_scheduler_event" {
   count               = var.ec2_start_scheduler != {} ? 1 : 0
   name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
   description         = "Event rule for EC2 start scheduler"
-  schedule_expression = var.ec2_start_scheduler[0].cron_expression
+  schedule_expression = var.ec2_start_scheduler.cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
@@ -126,7 +126,7 @@ resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
   target_id = aws_lambda_function.lambda_ec2_start[0].function_name
   arn       = aws_lambda_function.lambda_ec2_start[0].arn
   input = jsonencode({
-    instance_ids = var.ec2_start_scheduler[0].instance_ids
+    instance_ids = var.ec2_start_scheduler.instance_ids
   })
 }
 

--- a/main.tf
+++ b/main.tf
@@ -17,14 +17,14 @@ terraform {
 }
 
 data "archive_file" "lambda_asg" {
-  count       = var.asg_scheduler != {} ? 1 : 0
+  count       = var.asg_scheduler != null ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/lambda/ec2_asg/update_capacity"
   output_path = "${path.module}/lambda/ec2_asg/update_capacity/package.zip"
 }
 
 resource "aws_lambda_function" "lambda_asg" {
-  count            = var.asg_scheduler.asg_name != "" ? 1 : 0
+  count            = var.asg_scheduler != null ? 1 : 0
   function_name    = "ec2-asg-scheduler-${random_integer.random_number.result}"
   filename         = data.archive_file.lambda_asg[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_asg[0].output_path)
@@ -35,14 +35,14 @@ resource "aws_lambda_function" "lambda_asg" {
 
 
 resource "aws_cloudwatch_event_rule" "asg_downscale_scheduler_event" {
-  count               = var.asg_scheduler.asg_name != "" ? 1 : 0
+  count               = var.asg_scheduler != null ? 1 : 0
   name                = "asg-scheduler-downscale-event-${random_integer.random_number.result}"
   description         = "Event rule for ASG downscale scheduler"
   schedule_expression = var.asg_scheduler.downscale_cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
-  count     = var.asg_scheduler.asg_name != "" ? 1 : 0
+  count     = var.asg_scheduler != null ? 1 : 0
   rule      = aws_cloudwatch_event_rule.asg_downscale_scheduler_event[0].name
   target_id = aws_lambda_function.lambda_asg[0].function_name
   arn       = aws_lambda_function.lambda_asg[0].arn
@@ -53,14 +53,14 @@ resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
 }
 
 resource "aws_cloudwatch_event_rule" "asg_upscale_scheduler_event" {
-  count               = var.asg_scheduler.asg_name != "" ? 1 : 0
+  count               = var.asg_scheduler != null ? 1 : 0
   name                = "asg-scheduler-upsacale-event-${random_integer.random_number.result}"
   description         = "Event rule for ASG upscale scheduler"
   schedule_expression = var.asg_scheduler.upscale_cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
-  count     = var.asg_scheduler.asg_name != "" ? 1 : 0
+  count     = var.asg_scheduler != null ? 1 : 0
   rule      = aws_cloudwatch_event_rule.asg_upscale_scheduler_event[0].name
   target_id = aws_lambda_function.lambda_asg[0].function_name
   arn       = aws_lambda_function.lambda_asg[0].arn
@@ -71,14 +71,14 @@ resource "aws_cloudwatch_event_target" "asg_upscale_scheduler_target" {
 }
 
 data "archive_file" "lambda_ec2_stop" {
-  count       = var.ec2_stop_scheduler.cron_expression != "" ? 1 : 0
+  count       = var.ec2_stop_scheduler != null ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/lambda/ec2_simple/stop"
   output_path = "${path.module}/lambda/ec2_simple/stop/package.zip"
 }
 
 resource "aws_lambda_function" "lambda_ec2_stop" {
-  count            = var.ec2_stop_scheduler.cron_expression != "" ? 1 : 0
+  count            = var.ec2_stop_scheduler != null ? 1 : 0
   function_name    = "ec2-stop-scheduler-${random_integer.random_number.result}"
   filename         = data.archive_file.lambda_ec2_stop[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_stop[0].output_path)
@@ -88,14 +88,14 @@ resource "aws_lambda_function" "lambda_ec2_stop" {
 }
 
 resource "aws_cloudwatch_event_rule" "ec2_stop_scheduler_event" {
-  count               = var.ec2_stop_scheduler.cron_expression != "" ? 1 : 0
+  count               = var.ec2_stop_scheduler != null ? 1 : 0
   name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
   description         = "Event rule for EC2 stop scheduler"
   schedule_expression = var.ec2_stop_scheduler.cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
-  count     = var.ec2_stop_scheduler.cron_expression != "" ? 1 : 0
+  count     = var.ec2_stop_scheduler != null ? 1 : 0
   rule      = aws_cloudwatch_event_rule.ec2_stop_scheduler_event[0].name
   target_id = aws_lambda_function.lambda_ec2_stop[0].function_name
   arn       = aws_lambda_function.lambda_ec2_stop[0].arn
@@ -105,14 +105,14 @@ resource "aws_cloudwatch_event_target" "ec2_stop_scheduler_target" {
 }
 
 data "archive_file" "lambda_ec2_start" {
-  count       = var.ec2_start_scheduler.cron_expression != "" ? 1 : 0
+  count       = var.ec2_start_scheduler != null ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/lambda/ec2_simple/start"
   output_path = "${path.module}/lambda/ec2_simple/start/package.zip"
 }
 
 resource "aws_lambda_function" "lambda_ec2_start" {
-  count            = var.ec2_start_scheduler.cron_expression != "" ? 1 : 0
+  count            = var.ec2_start_scheduler != null ? 1 : 0
   function_name    = "ec2-start-scheduler-${random_integer.random_number.result}"
   filename         = data.archive_file.lambda_ec2_start[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_start[0].output_path)
@@ -122,14 +122,14 @@ resource "aws_lambda_function" "lambda_ec2_start" {
 }
 
 resource "aws_cloudwatch_event_rule" "ec2_start_scheduler_event" {
-  count               = var.ec2_start_scheduler.cron_expression != "" ? 1 : 0
+  count               = var.ec2_start_scheduler != null ? 1 : 0
   name                = "ec2-start-scheduler-event-${random_integer.random_number.result}"
   description         = "Event rule for EC2 start scheduler"
   schedule_expression = var.ec2_start_scheduler.cron_expression
 }
 
 resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
-  count     = var.ec2_start_scheduler.cron_expression != "" ? 1 : 0
+  count     = var.ec2_start_scheduler != null ? 1 : 0
   rule      = aws_cloudwatch_event_rule.ec2_start_scheduler_event[0].name
   target_id = aws_lambda_function.lambda_ec2_start[0].function_name
   arn       = aws_lambda_function.lambda_ec2_start[0].arn

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,14 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.2"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.5.0"
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,29 @@
 variable "asg_scheduler" {
   description = "The scheduler for updating ASG desired capacity"
-  type = map(object({
+  type = map({
     downscale_cron_expression  = string
     downscale_desired_capacity = number
     upscale_cron_expression    = string
     upscale_desired_capacity   = number
     asg_name                   = string
-  }))
+  })
   default = {}
 }
 
 variable "ec2_stop_scheduler" {
   description = "The scheduler for stopping the EC2 instances"
-  type = map(object({
+  type = map({
     cron_expression = string
     instance_ids    = list(string)
-  }))
+  })
   default = {}
 }
 
 variable "ec2_start_scheduler" {
   description = "The scheduler for starting the EC2 instances"
-  type = map(object({
+  type = map({
     cron_expression = string
     instance_ids    = list(string)
-  }))
+  })
   default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,29 @@
 variable "asg_scheduler" {
   description = "The scheduler for updating ASG desired capacity"
-  type = map({
+  type = map(object({
     downscale_cron_expression  = string
     downscale_desired_capacity = number
     upscale_cron_expression    = string
     upscale_desired_capacity   = number
     asg_name                   = string
-  })
+  }))
   default = {}
 }
 
 variable "ec2_stop_scheduler" {
   description = "The scheduler for stopping the EC2 instances"
-  type = map({
+  type = map(object({
     cron_expression = string
     instance_ids    = list(string)
-  })
+  }))
   default = {}
 }
 
 variable "ec2_start_scheduler" {
   description = "The scheduler for starting the EC2 instances"
-  type = map({
+  type = map(object({
     cron_expression = string
     instance_ids    = list(string)
-  })
+  }))
   default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,6 @@ variable "asg_scheduler" {
     upscale_desired_capacity   = number
     asg_name                   = string
   })
-  default = {}
 }
 
 variable "ec2_stop_scheduler" {
@@ -16,7 +15,6 @@ variable "ec2_stop_scheduler" {
     cron_expression = string
     instance_ids    = list(string)
   })
-  default = {}
 }
 
 variable "ec2_start_scheduler" {
@@ -25,5 +23,4 @@ variable "ec2_start_scheduler" {
     cron_expression = string
     instance_ids    = list(string)
   })
-  default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,29 @@
 variable "asg_scheduler" {
   description = "The scheduler for updating ASG desired capacity"
-  type = map(object({
+  type = object({
     downscale_cron_expression  = string
     downscale_desired_capacity = number
     upscale_cron_expression    = string
     upscale_desired_capacity   = number
     asg_name                   = string
-  }))
+  })
   default = {}
 }
 
 variable "ec2_stop_scheduler" {
   description = "The scheduler for stopping the EC2 instances"
-  type = map(object({
+  type = object({
     cron_expression = string
     instance_ids    = list(string)
-  }))
+  })
   default = {}
 }
 
 variable "ec2_start_scheduler" {
   description = "The scheduler for starting the EC2 instances"
-  type = map(object({
+  type = object({
     cron_expression = string
     instance_ids    = list(string)
-  }))
+  })
   default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,13 @@ variable "asg_scheduler" {
     upscale_desired_capacity   = number
     asg_name                   = string
   })
+  default = {
+    asg_name                   = ""
+    downscale_cron_expression  = ""
+    downscale_desired_capacity = 1
+    upscale_cron_expression    = ""
+    upscale_desired_capacity   = 2
+  }
 }
 
 variable "ec2_stop_scheduler" {
@@ -15,6 +22,10 @@ variable "ec2_stop_scheduler" {
     cron_expression = string
     instance_ids    = list(string)
   })
+  default = {
+    cron_expression = ""
+    instance_ids    = []
+  }
 }
 
 variable "ec2_start_scheduler" {
@@ -23,4 +34,8 @@ variable "ec2_start_scheduler" {
     cron_expression = string
     instance_ids    = list(string)
   })
+  default = {
+    cron_expression = ""
+    instance_ids    = []
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,29 @@
+variable "asg_scheduler" {
+  description = "The scheduler for updating ASG desired capacity"
+  type = map(object({
+    downscale_cron_expression  = string
+    downscale_desired_capacity = number
+    upscale_cron_expression    = string
+    upscale_desired_capacity   = number
+    asg_name                   = string
+  }))
+  default = {}
+}
+
+variable "ec2_stop_scheduler" {
+  description = "The scheduler for stopping the EC2 instances"
+  type = map(object({
+    cron_expression = string
+    instance_ids    = list(string)
+  }))
+  default = {}
+}
+
+variable "ec2_start_scheduler" {
+  description = "The scheduler for starting the EC2 instances"
+  type = map(object({
+    cron_expression = string
+    instance_ids    = list(string)
+  }))
+  default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -7,13 +7,7 @@ variable "asg_scheduler" {
     upscale_desired_capacity   = number
     asg_name                   = string
   })
-  default = {
-    asg_name                   = ""
-    downscale_cron_expression  = ""
-    downscale_desired_capacity = 1
-    upscale_cron_expression    = ""
-    upscale_desired_capacity   = 2
-  }
+  default = null
 }
 
 variable "ec2_stop_scheduler" {
@@ -22,10 +16,7 @@ variable "ec2_stop_scheduler" {
     cron_expression = string
     instance_ids    = list(string)
   })
-  default = {
-    cron_expression = ""
-    instance_ids    = []
-  }
+  default = null
 }
 
 variable "ec2_start_scheduler" {
@@ -34,8 +25,5 @@ variable "ec2_start_scheduler" {
     cron_expression = string
     instance_ids    = list(string)
   })
-  default = {
-    cron_expression = ""
-    instance_ids    = []
-  }
+  default = null
 }


### PR DESCRIPTION
Module allowing the possibility to add ec2 shut down and start, with or without autoscaling. 
The module is composed of 3 lambas:
- stop_ec2 (instance id + cron scheduler as input )
- start_ec2 (instance id + cron scheduler as input )
- asg_update_capacity (asg name + up cron scheduler + up desired capacity + down cron scheduler + down desired capacity as input)

They can work all together or the module can be called multiple times considering shutting down different "projects".

I still need to work on the readme file and provide some basic examples.