### PR TITLE
fix: do not deploy unnecessary resources by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,18 +25,18 @@ data "archive_file" "lambda_asg" {
 
 resource "aws_lambda_function" "lambda_asg" {
   count            = var.asg_scheduler != null ? 1 : 0
-  function_name    = "ec2-asg-scheduler-${random_id.this.id}"
+  function_name    = "ec2-asg-scheduler-${random_id.this[0].id}"
   filename         = data.archive_file.lambda_asg[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_asg[0].output_path)
   handler          = "main.lambda_handler"
   runtime          = "python3.8"
-  role             = aws_iam_role.lambda_role.arn
+  role             = aws_iam_role.lambda_role[0].arn
 }
 
 
 resource "aws_cloudwatch_event_rule" "asg_downscale_scheduler_event" {
   count               = var.asg_scheduler != null ? 1 : 0
-  name                = "asg-scheduler-downscale-event-${random_id.this.id}"
+  name                = "asg-scheduler-downscale-event-${random_id.this[0].id}"
   description         = "Event rule for ASG downscale scheduler"
   schedule_expression = var.asg_scheduler.downscale_cron_expression
 }
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_event_target" "asg_downscale_scheduler_target" {
 
 resource "aws_cloudwatch_event_rule" "asg_upscale_scheduler_event" {
   count               = var.asg_scheduler != null ? 1 : 0
-  name                = "asg-scheduler-upsacale-event-${random_id.this.id}"
+  name                = "asg-scheduler-upsacale-event-${random_id.this[0].id}"
   description         = "Event rule for ASG upscale scheduler"
   schedule_expression = var.asg_scheduler.upscale_cron_expression
 }
@@ -79,17 +79,17 @@ data "archive_file" "lambda_ec2_stop" {
 
 resource "aws_lambda_function" "lambda_ec2_stop" {
   count            = var.ec2_stop_scheduler != null ? 1 : 0
-  function_name    = "ec2-stop-scheduler-${random_id.this.id}"
+  function_name    = "ec2-stop-scheduler-${random_id.this[0].id}"
   filename         = data.archive_file.lambda_ec2_stop[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_stop[0].output_path)
   handler          = "main.lambda_handler"
   runtime          = "python3.8"
-  role             = aws_iam_role.lambda_role.arn
+  role             = aws_iam_role.lambda_role[0].arn
 }
 
 resource "aws_cloudwatch_event_rule" "ec2_stop_scheduler_event" {
   count               = var.ec2_stop_scheduler != null ? 1 : 0
-  name                = "ec2-start-scheduler-event-${random_id.this.id}"
+  name                = "ec2-start-scheduler-event-${random_id.this[0].id}"
   description         = "Event rule for EC2 stop scheduler"
   schedule_expression = var.ec2_stop_scheduler.cron_expression
 }
@@ -113,17 +113,17 @@ data "archive_file" "lambda_ec2_start" {
 
 resource "aws_lambda_function" "lambda_ec2_start" {
   count            = var.ec2_start_scheduler != null ? 1 : 0
-  function_name    = "ec2-start-scheduler-${random_id.this.id}"
+  function_name    = "ec2-start-scheduler-${random_id.this[0].id}"
   filename         = data.archive_file.lambda_ec2_start[0].output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_ec2_start[0].output_path)
   handler          = "main.lambda_handler"
   runtime          = "python3.8"
-  role             = aws_iam_role.lambda_role.arn
+  role             = aws_iam_role.lambda_role[0].arn
 }
 
 resource "aws_cloudwatch_event_rule" "ec2_start_scheduler_event" {
   count               = var.ec2_start_scheduler != null ? 1 : 0
-  name                = "ec2-start-scheduler-event-${random_id.this.id}"
+  name                = "ec2-start-scheduler-event-${random_id.this[0].id}"
   description         = "Event rule for EC2 start scheduler"
   schedule_expression = var.ec2_start_scheduler.cron_expression
 }
@@ -139,11 +139,21 @@ resource "aws_cloudwatch_event_target" "ec2_start_scheduler_target" {
 }
 
 resource "random_id" "this" {
+  count = (
+    var.ec2_start_scheduler != null ||
+    var.ec2_stop_scheduler != null ||
+    var.asg_scheduler != null
+  ) ? 1 : 0
   byte_length = 4
 }
 
 resource "aws_iam_role" "lambda_role" {
-  name               = "ec2-scheduler-role-${random_id.this.id}"
+  count = (
+    var.ec2_start_scheduler != null ||
+    var.ec2_stop_scheduler != null ||
+    var.asg_scheduler != null
+  ) ? 1 : 0
+  name               = "ec2-scheduler-role-${random_id.this[0].id}"
   assume_role_policy = data.aws_iam_policy_document.lambda_role_policy.json
 }
 
@@ -178,11 +188,21 @@ data "aws_iam_policy_document" "ec2_scheduler_policy" {
 }
 
 resource "aws_iam_policy" "ec2_scheduler_policy" {
-  name   = "ec2-scheduler-${random_id.this.id}"
+  count = (
+    var.ec2_start_scheduler != null ||
+    var.ec2_stop_scheduler != null ||
+    var.asg_scheduler != null
+  ) ? 1 : 0
+  name   = "ec2-scheduler-${random_id.this[0].id}"
   policy = data.aws_iam_policy_document.ec2_scheduler_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "attach_iam_policy_to_iam_role" {
-  role       = aws_iam_role.lambda_role.name
-  policy_arn = aws_iam_policy.ec2_scheduler_policy.arn
+  count = (
+    var.ec2_start_scheduler != null ||
+    var.ec2_stop_scheduler != null ||
+    var.asg_scheduler != null
+  ) ? 1 : 0
+  role       = aws_iam_role.lambda_role[0].name
+  policy_arn = aws_iam_policy.ec2_scheduler_policy[0].arn
 }


### PR DESCRIPTION
Given that the module could be called in a multienvironment account (dev/qua/prod) and might be only deployed to one specific env, it should expect to create 0 resources if we run it with no inputs