### PR TITLE
fix: ignore path-derived Lambda filename drift (FUM-4170)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,7 +24,7 @@ on:
       - 'renovate.json'
 
 env:
-  TERRAFORM_DOCS_VERSION: v0.19.0
+  TERRAFORM_DOCS_VERSION: v0.24.0
   TFLINT_VERSION: v0.44.1
 
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -99,7 +99,7 @@ jobs:
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
           install-hcledit: true
 
-  terraformTest:
+  terraform_test:
     name: terraform test
     runs-on: ubuntu-latest
     needs: collectInputs

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -98,3 +98,27 @@ jobs:
           tflint-version: ${{ env.TFLINT_VERSION }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
           install-hcledit: true
+
+  terraformTest:
+    name: terraform test
+    runs-on: ubuntu-latest
+    needs: collectInputs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Terraform min/max versions
+        id: minMax
+        uses: clowdhaus/terraform-min-max@v1.3.2
+
+      - name: Setup Terraform ${{ steps.minMax.outputs.maxVersion }}
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ steps.minMax.outputs.maxVersion }}
+
+      # Providers are mocked in the tests, so init without a backend is enough.
+      - name: Terraform init
+        run: terraform init -backend=false -input=false
+
+      - name: Terraform test
+        run: terraform test

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+# Lambda deployment packages built by the archive_file data sources on plan/apply/test
+lambda/**/package.zip

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ as described in the `.pre-commit-config.yaml` file
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
@@ -68,7 +68,7 @@ as described in the `.pre-commit-config.yaml` file
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
@@ -80,7 +80,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_log_group.lambda_asg_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.lambda_ec2_start_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.lambda_ec2_stop_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
@@ -113,7 +113,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_asg_scheduler"></a> [asg\_scheduler](#input\_asg\_scheduler) | The scheduler for updating ASG desired capacity | <pre>object({<br/>    downscale_cron_expression  = string<br/>    downscale_desired_capacity = number<br/>    upscale_cron_expression    = string<br/>    upscale_desired_capacity   = number<br/>    asg_name                   = string<br/>    description                = optional(string, "")<br/>  })</pre> | `null` | no |
 | <a name="input_ec2_start_scheduler"></a> [ec2\_start\_scheduler](#input\_ec2\_start\_scheduler) | The scheduler for starting the EC2 instances | <pre>object({<br/>    cron_expression = string<br/>    instance_ids    = list(string)<br/>    description     = optional(string, "")<br/>  })</pre> | `null` | no |
 | <a name="input_ec2_stop_scheduler"></a> [ec2\_stop\_scheduler](#input\_ec2\_stop\_scheduler) | The scheduler for stopping the EC2 instances | <pre>object({<br/>    cron_expression = string<br/>    instance_ids    = list(string)<br/>    description     = optional(string, "")<br/>  })</pre> | `null` | no |
@@ -121,7 +121,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_debug_ec2_scheduler"></a> [debug\_ec2\_scheduler](#output\_debug\_ec2\_scheduler) | scheduler ec2 |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,16 @@ resource "aws_lambda_function" "lambda_asg" {
   runtime          = "python3.12"
   role             = aws_iam_role.lambda_role[0].arn
   timeout          = 30
+
+  lifecycle {
+    # `filename` embeds `path.module`, which resolves to different strings
+    # (relative vs absolute) depending on the runner's working directory
+    # (e.g. local checkout vs Atlantis `/tmp/terraform-data-dir/`). This
+    # causes spurious in-place updates. `source_code_hash` already detects
+    # real code changes, so ignore the path-derived `filename`. Ignoring
+    # `filename` also stops the dependent `last_modified` churn.
+    ignore_changes = [filename]
+  }
 }
 
 resource "aws_iam_role" "asg_scheduler" {
@@ -138,6 +148,16 @@ resource "aws_lambda_function" "lambda_ec2_stop" {
   runtime          = "python3.12"
   role             = aws_iam_role.lambda_role[0].arn
   timeout          = 30
+
+  lifecycle {
+    # `filename` embeds `path.module`, which resolves to different strings
+    # (relative vs absolute) depending on the runner's working directory
+    # (e.g. local checkout vs Atlantis `/tmp/terraform-data-dir/`). This
+    # causes spurious in-place updates. `source_code_hash` already detects
+    # real code changes, so ignore the path-derived `filename`. Ignoring
+    # `filename` also stops the dependent `last_modified` churn.
+    ignore_changes = [filename]
+  }
 }
 
 resource "aws_iam_role" "ec2_stop_scheduler" {
@@ -217,6 +237,16 @@ resource "aws_lambda_function" "lambda_ec2_start" {
   runtime          = "python3.12"
   role             = aws_iam_role.lambda_role[0].arn
   timeout          = 30
+
+  lifecycle {
+    # `filename` embeds `path.module`, which resolves to different strings
+    # (relative vs absolute) depending on the runner's working directory
+    # (e.g. local checkout vs Atlantis `/tmp/terraform-data-dir/`). This
+    # causes spurious in-place updates. `source_code_hash` already detects
+    # real code changes, so ignore the path-derived `filename`. Ignoring
+    # `filename` also stops the dependent `last_modified` churn.
+    ignore_changes = [filename]
+  }
 }
 
 resource "aws_iam_role" "ec2_start_scheduler" {

--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,7 @@ resource "aws_lambda_function" "lambda_asg" {
   timeout          = 30
 
   lifecycle {
-    # `filename` embeds `path.module`, which resolves to different strings
-    # (relative vs absolute) depending on the runner's working directory
-    # (e.g. local checkout vs Atlantis `/tmp/terraform-data-dir/`). This
-    # causes spurious in-place updates. `source_code_hash` already detects
-    # real code changes, so ignore the path-derived `filename`. Ignoring
-    # `filename` also stops the dependent `last_modified` churn.
+    # filename embeds path.module, which varies by working dir; source_code_hash detects real changes
     ignore_changes = [filename]
   }
 }
@@ -150,12 +145,7 @@ resource "aws_lambda_function" "lambda_ec2_stop" {
   timeout          = 30
 
   lifecycle {
-    # `filename` embeds `path.module`, which resolves to different strings
-    # (relative vs absolute) depending on the runner's working directory
-    # (e.g. local checkout vs Atlantis `/tmp/terraform-data-dir/`). This
-    # causes spurious in-place updates. `source_code_hash` already detects
-    # real code changes, so ignore the path-derived `filename`. Ignoring
-    # `filename` also stops the dependent `last_modified` churn.
+    # filename embeds path.module, which varies by working dir; source_code_hash detects real changes
     ignore_changes = [filename]
   }
 }
@@ -239,12 +229,7 @@ resource "aws_lambda_function" "lambda_ec2_start" {
   timeout          = 30
 
   lifecycle {
-    # `filename` embeds `path.module`, which resolves to different strings
-    # (relative vs absolute) depending on the runner's working directory
-    # (e.g. local checkout vs Atlantis `/tmp/terraform-data-dir/`). This
-    # causes spurious in-place updates. `source_code_hash` already detects
-    # real code changes, so ignore the path-derived `filename`. Ignoring
-    # `filename` also stops the dependent `last_modified` churn.
+    # filename embeds path.module, which varies by working dir; source_code_hash detects real changes
     ignore_changes = [filename]
   }
 }

--- a/tests/lambda_scheduler.tftest.hcl
+++ b/tests/lambda_scheduler.tftest.hcl
@@ -1,0 +1,151 @@
+# Contract/smoke tests for the up/down scheduler module.
+#
+# AWS and random are mocked so the tests run offline with no credentials.
+# The `archive` provider is intentionally NOT mocked so the real
+# `archive_file` data sources zip the `lambda/` sources and
+# `filebase64sha256(...)` computes a real hash — the same path a real plan
+# takes.
+#
+# NOTE: these tests do not reproduce the working-directory `filename` drift
+# fixed in FUM-4170. That drift only appears when Terraform is invoked from
+# different data dirs (local checkout vs Atlantis `/tmp/terraform-data-dir/`),
+# which `terraform test` cannot vary, so an idempotency check would pass with
+# or without the `ignore_changes = [filename]` fix. These are contract tests
+# that assert the module wires the Lambda functions up correctly.
+
+# The mocked aws provider generates random strings for computed `arn`
+# attributes, which fail the provider's ARN-format validation when they are
+# fed into `role` / `policy_arn`. Provide valid mock ARNs for the IAM
+# resources so the graph applies.
+mock_provider "aws" {
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/mock-role"
+    }
+  }
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock-policy"
+    }
+  }
+  mock_resource "aws_lambda_function" {
+    defaults = {
+      arn = "arn:aws:lambda:eu-central-1:123456789012:function:mock-fn"
+    }
+  }
+}
+mock_provider "random" {}
+
+# The mocked aws provider also stubs the `aws_iam_policy_document` data
+# sources, which would return empty `json` and fail the IAM policy JSON
+# validation. Override them with valid (representative) policy JSON.
+override_data {
+  target = data.aws_iam_policy_document.lambda_role_policy
+  values = {
+    json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"}}]}"
+  }
+}
+
+override_data {
+  target = data.aws_iam_policy_document.ec2_scheduler_policy
+  values = {
+    json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"ec2:StartInstances\",\"ec2:StopInstances\"],\"Resource\":\"*\"}]}"
+  }
+}
+
+# All three schedulers enabled -> all three Lambda functions exist and are
+# configured with the expected runtime/handler and a real source_code_hash.
+run "all_schedulers_enabled" {
+  command = apply
+
+  variables {
+    asg_scheduler = {
+      downscale_cron_expression  = "cron(0 19 * * ? *)"
+      downscale_desired_capacity = 0
+      upscale_cron_expression    = "cron(0 7 * * ? *)"
+      upscale_desired_capacity   = 2
+      asg_name                   = "my-asg"
+      description                = "test asg scheduler"
+    }
+    ec2_stop_scheduler = {
+      cron_expression = "cron(0 19 * * ? *)"
+      instance_ids    = ["i-0123456789abcdef0"]
+      description     = "test stop scheduler"
+    }
+    ec2_start_scheduler = {
+      cron_expression = "cron(0 7 * * ? *)"
+      instance_ids    = ["i-0123456789abcdef0"]
+      description     = "test start scheduler"
+    }
+  }
+
+  assert {
+    condition     = length(aws_lambda_function.lambda_asg) == 1
+    error_message = "asg Lambda should be created when asg_scheduler is set"
+  }
+
+  assert {
+    condition     = length(aws_lambda_function.lambda_ec2_stop) == 1
+    error_message = "ec2 stop Lambda should be created when ec2_stop_scheduler is set"
+  }
+
+  assert {
+    condition     = length(aws_lambda_function.lambda_ec2_start) == 1
+    error_message = "ec2 start Lambda should be created when ec2_start_scheduler is set"
+  }
+
+  assert {
+    condition = alltrue([
+      aws_lambda_function.lambda_asg[0].runtime == "python3.12",
+      aws_lambda_function.lambda_ec2_stop[0].runtime == "python3.12",
+      aws_lambda_function.lambda_ec2_start[0].runtime == "python3.12",
+    ])
+    error_message = "all Lambdas should use the python3.12 runtime"
+  }
+
+  assert {
+    condition = alltrue([
+      aws_lambda_function.lambda_asg[0].handler == "main.lambda_handler",
+      aws_lambda_function.lambda_ec2_stop[0].handler == "main.lambda_handler",
+      aws_lambda_function.lambda_ec2_start[0].handler == "main.lambda_handler",
+    ])
+    error_message = "all Lambdas should use the main.lambda_handler entrypoint"
+  }
+
+  # source_code_hash is what actually detects real code changes; it must be
+  # populated from the archived package for every Lambda.
+  assert {
+    condition = alltrue([
+      aws_lambda_function.lambda_asg[0].source_code_hash != "",
+      aws_lambda_function.lambda_ec2_stop[0].source_code_hash != "",
+      aws_lambda_function.lambda_ec2_start[0].source_code_hash != "",
+    ])
+    error_message = "all Lambdas should have a non-empty source_code_hash"
+  }
+}
+
+# Only the ec2 stop scheduler enabled -> only that Lambda exists; the asg and
+# start Lambdas are not created.
+run "only_ec2_stop_enabled" {
+  command = apply
+
+  variables {
+    ec2_stop_scheduler = {
+      cron_expression = "cron(0 19 * * ? *)"
+      instance_ids    = ["i-0123456789abcdef0"]
+    }
+  }
+
+  assert {
+    condition     = length(aws_lambda_function.lambda_ec2_stop) == 1
+    error_message = "ec2 stop Lambda should be created when ec2_stop_scheduler is set"
+  }
+
+  assert {
+    condition = alltrue([
+      length(aws_lambda_function.lambda_asg) == 0,
+      length(aws_lambda_function.lambda_ec2_start) == 0,
+    ])
+    error_message = "only the ec2 stop Lambda should exist when only ec2_stop_scheduler is set"
+  }
+}

--- a/tests/lambda_scheduler.tftest.hcl
+++ b/tests/lambda_scheduler.tftest.hcl
@@ -42,14 +42,28 @@ mock_provider "random" {}
 override_data {
   target = data.aws_iam_policy_document.lambda_role_policy
   values = {
-    json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"}}]}"
+    json = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect    = "Allow"
+        Action    = "sts:AssumeRole"
+        Principal = { Service = "lambda.amazonaws.com" }
+      }]
+    })
   }
 }
 
 override_data {
   target = data.aws_iam_policy_document.ec2_scheduler_policy
   values = {
-    json = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"ec2:StartInstances\",\"ec2:StopInstances\"],\"Resource\":\"*\"}]}"
+    json = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect   = "Allow"
+        Action   = ["ec2:StartInstances", "ec2:StopInstances"]
+        Resource = "*"
+      }]
+    })
   }
 }
 

--- a/tests/lambda_scheduler.tftest.hcl
+++ b/tests/lambda_scheduler.tftest.hcl
@@ -1,22 +1,7 @@
-# Contract/smoke tests for the up/down scheduler module.
-#
-# AWS and random are mocked so the tests run offline with no credentials.
-# The `archive` provider is intentionally NOT mocked so the real
-# `archive_file` data sources zip the `lambda/` sources and
-# `filebase64sha256(...)` computes a real hash — the same path a real plan
-# takes.
-#
-# NOTE: these tests do not reproduce the working-directory `filename` drift
-# fixed in FUM-4170. That drift only appears when Terraform is invoked from
-# different data dirs (local checkout vs Atlantis `/tmp/terraform-data-dir/`),
-# which `terraform test` cannot vary, so an idempotency check would pass with
-# or without the `ignore_changes = [filename]` fix. These are contract tests
-# that assert the module wires the Lambda functions up correctly.
+# aws/random are mocked so the suite runs offline; archive is left real so
+# archive_file zips the lambda sources and source_code_hash is computed.
 
-# The mocked aws provider generates random strings for computed `arn`
-# attributes, which fail the provider's ARN-format validation when they are
-# fed into `role` / `policy_arn`. Provide valid mock ARNs for the IAM
-# resources so the graph applies.
+# Mock ARNs so the provider's ARN-format validation passes on role/policy_arn.
 mock_provider "aws" {
   mock_resource "aws_iam_role" {
     defaults = {
@@ -36,9 +21,7 @@ mock_provider "aws" {
 }
 mock_provider "random" {}
 
-# The mocked aws provider also stubs the `aws_iam_policy_document` data
-# sources, which would return empty `json` and fail the IAM policy JSON
-# validation. Override them with valid (representative) policy JSON.
+# Valid policy JSON so IAM policy validation passes (mocked docs return empty).
 override_data {
   target = data.aws_iam_policy_document.lambda_role_policy
   values = {
@@ -67,8 +50,6 @@ override_data {
   }
 }
 
-# All three schedulers enabled -> all three Lambda functions exist and are
-# configured with the expected runtime/handler and a real source_code_hash.
 run "all_schedulers_enabled" {
   command = apply
 
@@ -126,8 +107,6 @@ run "all_schedulers_enabled" {
     error_message = "all Lambdas should use the main.lambda_handler entrypoint"
   }
 
-  # source_code_hash is what actually detects real code changes; it must be
-  # populated from the archived package for every Lambda.
   assert {
     condition = alltrue([
       aws_lambda_function.lambda_asg[0].source_code_hash != "",
@@ -138,8 +117,6 @@ run "all_schedulers_enabled" {
   }
 }
 
-# Only the ec2 stop scheduler enabled -> only that Lambda exists; the asg and
-# start Lambdas are not created.
 run "only_ec2_stop_enabled" {
   command = apply
 


### PR DESCRIPTION
## Summary

Fixes spurious `terraform plan` drift on the module's Lambda functions (FUM-4170).

The three `aws_lambda_function` resources set `filename` from `data.archive_file.*.output_path`, which embeds `path.module`. `path.module` resolves to a **relative** path in a local checkout but an **absolute** path under runners that set a custom data dir (e.g. Atlantis `/tmp/terraform-data-dir/`). That string is stored verbatim in state, so `terraform plan` showed spurious in-place updates to `filename` (and the dependent `last_modified`) on every run, obscuring real changes and triggering needless Lambda deployments.

`source_code_hash` already detects real code changes, so this adds `lifecycle { ignore_changes = [filename] }` to `lambda_asg`, `lambda_ec2_stop`, and `lambda_ec2_start`. This is the preferred upstream fix from the ticket (rely on `source_code_hash`), applied directly in this module rather than as a downstream stopgap.

## Changes

- **fix:** `lifecycle { ignore_changes = [filename] }` on all three Lambda functions (incl. the ASG variant, which had the same drift).
- **test:** first tests for this module — native `terraform test` contract tests (`tests/lambda_scheduler.tftest.hcl`) with mocked aws/random providers (run offline); a `terraformTest` CI job; and gitignore for `lambda/**/package.zip` build artifacts.
- **ci:** bump `terraform-docs` pin `v0.19.0` → `v0.24.0` and regenerate `README.md` to stop separator-format churn between CI and local runs.

## Verification

- `terraform validate` — Success, no warnings.
- `terraform test` — `2 passed, 0 failed`.
- `pre-commit run --all-files` — all hooks pass.

## Note / limitation

The tests are **contract/smoke tests** — they assert the module wires the Lambdas correctly (runtime, handler, populated `source_code_hash`, per-scheduler resource counts). They do **not** reproduce the working-directory `filename` drift itself, since `terraform test` can't vary the data dir (an idempotency check would pass with or without the fix). Per the ticket AC, a clean plan should still be confirmed from both a local run and an Atlantis run (e.g. `claro02`).